### PR TITLE
Initial packaging of gotestsum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+_topdir/
+*.tar.*
+*.code-workspace

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "packaging"]
+	path = packaging
+	url = https://github.com/daos-stack/packaging.git
+	branch = master

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,40 @@
+#!/usr/bin/groovy
+/* Copyright (C) 2019 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ *  4. All publications or advertising materials mentioning features or use of
+ *     this software are asked, but not required, to acknowledge that it was
+ *     developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+packageBuildingPipeline(['distros': ['centos7']])

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+NAME         := gotestsum
+SRC_EXT      := gz
+MOCK_OPTIONS := --enable-network # needed to download modules
+
+include packaging/Makefile_packaging.mk
+
+clean:
+	git clean -dfx .

--- a/gotestsum.spec
+++ b/gotestsum.spec
@@ -1,0 +1,35 @@
+%global debug_package %{nil}
+
+Name:           gotestsum
+Version:        0.4.0
+Release:        1%{?dist}
+Summary:        `go test` runner with output optimized for humans, JUnit XML for CI integration, and a summary of the test results
+
+Group:          Development/Tools
+License:        ASL 2.0
+URL:            https://github.com/gotestyourself/gotestsum
+Source0:        https://github.com/gotestyourself/%{name}/archive/v%{version}.tar.gz
+
+BuildRequires: go >= 1.13
+
+%description
+gotestsum runs tests, prints friendly test output and a summary of the test run.
+
+%prep
+%setup -q -n %{name}-%{version}%{?ver_add}
+
+%build
+go version
+go build -v
+
+%install
+install -d -m 755 %{buildroot}%{_bindir}
+install -p -m 755 %{name} %{buildroot}%{_bindir}/
+
+%files
+%doc LICENSE NOTICE README.md
+%{_bindir}/%{name}
+
+%changelog
+* Fri Feb 07 2020 Michael MacDonald <mjmac.macdonald@intel.com> - 0.4.0-1
+- Initial package


### PR DESCRIPTION
Provides a `go test` wrapper that emits test reports in the
JUnit format.